### PR TITLE
Excluded filename from node creation with an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ options:
 
 - `allowEmpty` _(default: false)_ - allow an empty file to appear in the generated result. When set to true, an empty file named `empty.yaml` will be represented as `empty: {}`.
 - `recursive` _(default: true)_ - Specifies whether or not to recurse into subdirectories.
+- `excludeFileNameFromNode` _(default: false)_ - If true, it will not create an additional node in the object with the file name included.
 - `extensions` _(default: ['.yaml', '.yml'])_ - Determines file extensions to consider for inclusion.
 - `lowerKeys` _(default: false)_ - Force all keys gleaned from the directory hierarchy to lower case.
 - `variableIndicator` _(default: '~')_ - When a file or directory name is prefixed with this character, the representation in the generated output will be wrapped in the `variablePrefix` and `variableSuffix` strings.

--- a/lib/dir.js
+++ b/lib/dir.js
@@ -38,6 +38,7 @@ function constructIncludedDirectory(data) {
     variableSuffix: '}',
     ignoreIndicator: '_',
     ignoreTopLevelDir: true,
+    excludeFileNameFromNode: false,
     excludeTopLevelDirSeparator: false,
     pathSeparator: '/'
   };
@@ -166,7 +167,11 @@ function constructIncludedDirectory(data) {
         tmp[filename] = included;
       } else {
         if (Object.getOwnPropertyNames(included).length > 0) {
-          tmp[filename] = included;
+          if (opt.excludeFileNameFromNode) {
+            tmp = merge(tmp, included);
+          }else {
+            tmp[filename] = included;
+          }
         }
       }
     }


### PR DESCRIPTION
Hi! 
here is a patch that includes a change that I think it could be useful.

sometimes you need to create an object that does not take the file name as a node. I added an option for this